### PR TITLE
Add summary generator and Unity prefab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+report/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # VR_RacingClubTW
+
+This repository contains utilities for reading racing data from a public
+Google Spreadsheet and showing the processed results inside VRChat.
+
+## fetch_sheet.py
+
+`fetch_sheet.py` downloads the `歷史紀錄` worksheet from the public Google
+Spreadsheet identified by the ID `1ifyJiZfDAJD4kf-67puKALA2ikEHCSrnw02dvewdFO0`.
+The script exports the sheet as CSV and prints each row. It requires Python 3 and
+internet access. Run it with:
+
+```bash
+python3 fetch_sheet.py
+```
+
+If the environment blocks outbound network requests the script will fail with a
+`403 Forbidden` error.
+
+## generate_summary.py
+
+`generate_summary.py` builds a small text report from the spreadsheet data.
+The file `report/summary.txt` will be created containing a list of statistics.
+
+```bash
+python3 generate_summary.py
+```
+
+The script relies on `fetch_sheet.py` and therefore also requires internet
+access.
+
+## prefab/TextDisplay.cs
+
+`prefab/TextDisplay.cs` is a simple Unity component that downloads a text file
+from a URL and displays it in a `Text` UI element. Attach it to a prefab and set
+the `url` and `targetText` fields in the Inspector.

--- a/fetch_sheet.py
+++ b/fetch_sheet.py
@@ -1,0 +1,55 @@
+"""Download racing data from a public Google Spreadsheet.
+
+This module exposes a :func:`fetch_sheet` function returning the CSV rows so
+other scripts can easily consume the data.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import urllib.parse
+import urllib.request
+from typing import List
+
+
+SHEET_ID = "1ifyJiZfDAJD4kf-67puKALA2ikEHCSrnw02dvewdFO0"
+"""Spreadsheet ID containing racing data."""
+
+SHEET_NAME = "歷史紀錄"
+"""Worksheet name with the historical records."""
+
+
+def fetch_sheet(sheet_id: str = SHEET_ID, sheet_name: str = SHEET_NAME) -> List[List[str]]:
+    """Return the worksheet contents as a list of rows.
+
+    Parameters
+    ----------
+    sheet_id:
+        The spreadsheet identifier.
+    sheet_name:
+        The specific worksheet name to download.
+    """
+
+    sheet_name_encoded = urllib.parse.quote(sheet_name)
+    url = (
+        f"https://docs.google.com/spreadsheets/d/{sheet_id}/gviz/tq?tqx=out:csv&sheet="
+        f"{sheet_name_encoded}"
+    )
+
+    print(f"Fetching data from: {url}")
+
+    try:
+        with urllib.request.urlopen(url) as response:
+            csv_data = response.read().decode("utf-8")
+    except Exception as e:  # pragma: no cover - network errors are environment specific
+        print("Failed to fetch data:", e)
+        raise
+
+    reader = csv.reader(io.StringIO(csv_data))
+    return list(reader)
+
+
+if __name__ == "__main__":
+    for row in fetch_sheet():
+        print(row)

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from typing import List
+
+from fetch_sheet import fetch_sheet
+
+
+OUTPUT_DIR = "report"
+OUTPUT_FILE = os.path.join(OUTPUT_DIR, "summary.txt")
+
+
+def summarise(rows: List[List[str]]) -> List[str]:
+    if not rows:
+        return ["No data fetched."]
+
+    header, *data = rows
+    summary = [f"Total entries: {len(data)}"]
+
+    if "賽道" in header and "時間" in header:
+        track_idx = header.index("賽道")
+        time_idx = header.index("時間")
+        best_by_track: dict[str, float] = {}
+        for row in data:
+            if len(row) <= max(track_idx, time_idx):
+                continue
+            track = row[track_idx]
+            try:
+                t = float(row[time_idx])
+            except ValueError:
+                continue
+            if track not in best_by_track or t < best_by_track[track]:
+                best_by_track[track] = t
+        summary.append("Fastest per track:")
+        for track, t in best_by_track.items():
+            summary.append(f"{track}: {t}")
+    return summary
+
+
+def main() -> None:
+    try:
+        rows = fetch_sheet()
+    except Exception:
+        rows = []
+    lines = summarise(rows)
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as fh:
+        for line in lines:
+            fh.write(line + "\n")
+    print(f"Summary written to {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prefab/TextDisplay.cs
+++ b/prefab/TextDisplay.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.UI;
+
+public class TextDisplay : MonoBehaviour
+{
+    [Tooltip("URL of the summary text file")]
+    public string url;
+
+    [Tooltip("UI Text component to display the contents")]
+    public Text targetText;
+
+    private void Start()
+    {
+        if (!string.IsNullOrEmpty(url) && targetText != null)
+        {
+            StartCoroutine(DownloadText());
+        }
+    }
+
+    private IEnumerator DownloadText()
+    {
+        using (UnityWebRequest request = UnityWebRequest.Get(url))
+        {
+            yield return request.SendWebRequest();
+            if (request.result == UnityWebRequest.Result.Success)
+            {
+                targetText.text = request.downloadHandler.text;
+            }
+            else
+            {
+                targetText.text = "Failed to load";
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `fetch_sheet.py` to expose `fetch_sheet()`
- add `generate_summary.py` to build a simple text report
- create Unity component `TextDisplay` for showing the report
- update README with instructions
- ignore build artifacts

## Testing
- `python3 generate_summary.py` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python3 fetch_sheet.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6876f4ba5640832dba7b56d358ff59e7