### PR TITLE
Add auth options to world scraper

### DIFF
--- a/world_info/scraper/scraper.py
+++ b/world_info/scraper/scraper.py
@@ -3,15 +3,16 @@
 
 This script queries the unofficial VRChat API to fetch world information
 and stores the results as a JSON list.  Authentication headers such as
-cookies should be provided in ``headers.json``.  The file is ignored by
-git so your credentials remain local.
+cookies can be supplied in ``headers.json`` or via command line options.
+The credentials file is ignored by git so your secrets remain local.
 """
 
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 import time
 
 import requests
@@ -20,25 +21,42 @@ BASE = Path(__file__).parent
 HEADERS_FILE = BASE / "headers.json"
 
 
-def _load_headers() -> Dict[str, str]:
-    """Load HTTP headers from ``headers.json`` if it exists."""
+def _load_headers(cookie: Optional[str] = None,
+                  username: Optional[str] = None,
+                  password: Optional[str] = None) -> Dict[str, str]:
+    """Load HTTP headers from ``headers.json`` and command line options."""
+
+    headers = {"User-Agent": "Mozilla/5.0"}
+
     if HEADERS_FILE.exists():
         with open(HEADERS_FILE, "r", encoding="utf-8") as f:
-            return json.load(f)
-    return {"User-Agent": "Mozilla/5.0"}
+            try:
+                headers.update(json.load(f))
+            except json.JSONDecodeError:
+                pass
+
+    if cookie:
+        headers["Cookie"] = cookie
+
+    if username and password:
+        token = base64.b64encode(f"{username}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {token}"
+
+    return headers
 
 
-HEADERS = _load_headers()
+HEADERS: Dict[str, str] = _load_headers()
 
 
-def _fetch_paginated(base_url: str, limit: int, delay: float) -> List[dict]:
+def _fetch_paginated(base_url: str, limit: int, delay: float,
+                     headers: Optional[Dict[str, str]] = None) -> List[dict]:
     """Fetch up to ``limit`` worlds from ``base_url`` using pagination."""
     results: List[dict] = []
     offset = 0
     while len(results) < limit:
         remaining = min(60, limit - len(results))
         url = f"{base_url}&n={remaining}&offset={offset}"
-        r = requests.get(url, headers=HEADERS, timeout=30)
+        r = requests.get(url, headers=headers or HEADERS, timeout=30)
         r.raise_for_status()
         chunk = r.json()
         if not isinstance(chunk, list):
@@ -51,14 +69,16 @@ def _fetch_paginated(base_url: str, limit: int, delay: float) -> List[dict]:
     return results[:limit]
 
 
-def search_worlds(keyword: str, limit: int = 20, delay: float = 1.0) -> List[dict]:
+def search_worlds(keyword: str, limit: int = 20, delay: float = 1.0,
+                  headers: Optional[Dict[str, str]] = None) -> List[dict]:
     base = f"https://api.vrchat.cloud/api/1/worlds?search={keyword}"
-    return _fetch_paginated(base, limit, delay)
+    return _fetch_paginated(base, limit, delay, headers)
 
 
-def get_user_worlds(user_id: str, limit: int = 20, delay: float = 1.0) -> List[dict]:
+def get_user_worlds(user_id: str, limit: int = 20, delay: float = 1.0,
+                    headers: Optional[Dict[str, str]] = None) -> List[dict]:
     base = f"https://api.vrchat.cloud/api/1/users/{user_id}/worlds?"
-    return _fetch_paginated(base, limit, delay)
+    return _fetch_paginated(base, limit, delay, headers)
 
 
 def extract_info(world: dict) -> Dict[str, object]:
@@ -80,6 +100,20 @@ def extract_info(world: dict) -> Dict[str, object]:
     }
 
 
+def fetch_worlds(*,
+                 keyword: Optional[str] = None,
+                 user_id: Optional[str] = None,
+                 limit: int = 20,
+                 delay: float = 1.0,
+                 headers: Optional[Dict[str, str]] = None) -> List[dict]:
+    """High level helper to fetch worlds by keyword or user ID."""
+    if keyword:
+        return search_worlds(keyword, limit, delay, headers)
+    if user_id:
+        return get_user_worlds(user_id, limit, delay, headers)
+    raise ValueError("keyword or user_id required")
+
+
 def main() -> None:
     import argparse
 
@@ -89,12 +123,18 @@ def main() -> None:
     parser.add_argument("--limit", type=int, default=20, help="maximum worlds")
     parser.add_argument("--delay", type=float, default=1.0, help="seconds between requests")
     parser.add_argument("--out", type=Path, default=BASE / "raw_worlds.json", help="output JSON path")
+    parser.add_argument("--cookie", help="authentication cookie string")
+    parser.add_argument("--username", help="basic auth username")
+    parser.add_argument("--password", help="basic auth password")
     args = parser.parse_args()
 
+    global HEADERS
+    HEADERS = _load_headers(args.cookie, args.username, args.password)
+
     if args.keyword:
-        worlds = search_worlds(args.keyword, args.limit, args.delay)
+        worlds = search_worlds(args.keyword, args.limit, args.delay, HEADERS)
     elif args.user:
-        worlds = get_user_worlds(args.user, args.limit, args.delay)
+        worlds = get_user_worlds(args.user, args.limit, args.delay, HEADERS)
     else:
         parser.error("--keyword or --user is required")
 


### PR DESCRIPTION
## Summary
- support cookie and basic auth login in world_info scraper
- expose helper to fetch worlds programmatically

## Testing
- `python -m py_compile world_info/scraper/scraper.py`
- `pip install requests` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6886da21df6c832da5455e0368c9dcb0