### PR TITLE
Handle missing optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,11 @@ See [`world_info/README.md`](world_info/README.md) for details.
 Additional background is available in
 [`world_info/complete_guide.zh_TW.md`](world_info/complete_guide.zh_TW.md) (Chinese).
 
+Install dependencies with::
+
+  pip install -r requirements.txt
+
+If creator-world scraping is required, run ``playwright install`` after installing the packages.
+
 For Traditional Chinese instructions, read
 [`README.zh_TW.md`](README.zh_TW.md).

--- a/README.zh_TW.md
+++ b/README.zh_TW.md
@@ -10,6 +10,18 @@
 更完整的架構與流程說明請見
 [`world_info/complete_guide.zh_TW.md`](world_info/complete_guide.zh_TW.md)。
 
+安裝相依套件：
+
+```bash
+pip install -r requirements.txt
+```
+
+若要爬取作者世界，請於安裝後執行：
+
+```bash
+playwright install
+```
+
 ---
 
 ## 檔案結構

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+playwright
+openpyxl

--- a/world_info/README.md
+++ b/world_info/README.md
@@ -10,7 +10,7 @@ world_info/
 │  ├─ review_tool.py      # mark worlds as approved
 │  ├─ exporter.py         # create approved_export.json
 │  └─ raw_worlds.json     # generated sample data
-├─ ui.py                  # simple tkinter review interface
+├─ ui.py                  # Tkinter interface for login and world search
 ├─ docs/
 │  ├─ index.html          # page listing approved worlds with filters
 │  └─ approved_export.json
@@ -18,17 +18,40 @@ world_info/
    └─ GenerateWorldCards.cs
 ```
 
+Install the required Python packages with::
+
+  pip install -r requirements.txt
+
+If you plan to fetch a creator's worlds, also run::
+
+  playwright install
+
 Create ``scraper/headers.json`` with your login cookie::
 
   {"Cookie": "auth=...; twoFactorAuth=...; machineId=..."}
 
 Run the tools in order:
 
-1. ``python3 scraper/scraper.py --keyword Taiwan --limit 50`` to search worlds
-   or ``python3 scraper/scraper.py --user usr_abc123 --limit 50`` to fetch a
-   creator's worlds.  Results are written to ``raw_worlds.json``.
-2. ``python3 scraper/review_tool.py`` (or run ``python3 ui.py`` for a GUI)
+1. ``python3 scraper/scraper.py --keyword Taiwan --limit 50`` to search worlds.
+   To collect a creator's worlds, use ``--user usr_abc123`` which will launch a
+   headless browser via Playwright to scrape ``https://vrchat.com/home/user`` and
+   then query each world ID.  Add ``--cookie``, ``--username`` or ``--password``
+   to supply authentication headers. Results are written to ``raw_worlds.json``.
+2. ``python3 scraper/review_tool.py`` (optional) or run ``python3 ui.py`` for
+   an interface that lets you log in, fetch worlds and apply filters. The world
+   list tab now shows results in a sortable table. A new "History" tab tracks
+   visits, favorites and heat over time with a simple line chart. Each fetch
+   also appends a row to ``scraper/history_table.xlsx`` and ``scraper/worlds.xlsx``
+   with additional metrics like visit/favorite ratio and days since last update.
+   If ``openpyxl`` is not installed, ``history_table.csv`` and ``worlds.csv`` are
+   written instead. ``worlds.xlsx`` (or ``worlds.csv``) can be opened in Excel to
+   edit or import existing data.
 3. ``python3 scraper/exporter.py``
+
+Fetching a creator's worlds requires the ``playwright`` package.  Install it and
+run ``playwright install`` before using the ``--user`` option.  If the package
+is missing, the UI will still run but the creator-world feature will be
+disabled.
 
 Copy `scraper/approved_export.json` into `docs/` to update the website or load
 it inside Unity using the `GenerateWorldCards` editor script.

--- a/world_info/README.zh_TW.md
+++ b/world_info/README.zh_TW.md
@@ -10,12 +10,24 @@ world_info/
 │  ├─ review_tool.py      # 標記世界是否核可
 │  ├─ exporter.py         # 產生 approved_export.json
 │  └─ raw_worlds.json     # 產生的範例資料
-├─ ui.py                  # Tkinter 審核介面
+├─ ui.py                  # Tkinter 介面，可登入並搜尋世界
 ├─ docs/
 │  ├─ index.html          # 提供篩選功能的世界清單頁面
 │  └─ approved_export.json
 └─ unity_prefab_generator/
    └─ GenerateWorldCards.cs
+```
+
+執行前請先安裝 Python 套件：
+
+```bash
+pip install -r requirements.txt
+```
+
+若需抓取作者世界，再執行：
+
+```bash
+playwright install
 ```
 
 請在 ``scraper/headers.json`` 中輸入登入後取得的 Cookie，例如：
@@ -26,11 +38,22 @@ world_info/
 
 執行流程：
 
-1. `python3 scraper/scraper.py --keyword Taiwan --limit 50` 以關鍵字搜尋世界，
-   或 `python3 scraper/scraper.py --user usr_abc123 --limit 50` 取得指定作者世界，
+1. `python3 scraper/scraper.py --keyword Taiwan --limit 50` 以關鍵字搜尋世界。
+   若要抓取某作者世界，使用 `--user usr_abc123`，會透過 Playwright 在
+   `https://vrchat.com/home/user/` 頁面爬取 worldId，再查詢詳細資料。
+   可額外加入 `--cookie`、`--username` 或 `--password` 提供驗證資訊，
    結果會輸出到 `raw_worlds.json`。
-2. `python3 scraper/review_tool.py`（或執行 `python3 ui.py` 使用圖形介面）
+2. `python3 scraper/review_tool.py`（可選）或執行 `python3 ui.py`，
+   透過圖形介面登入並搜尋、篩選世界。世界列表頁以表格方式呈現資料，
+   並新增「歷史記錄」分頁，可追蹤瀏覽人數、收藏數與熱度變化折線圖。
+   每次抓取資料也會在 `scraper/history_table.xlsx` 與 `scraper/worlds.xlsx`
+   追加一行，記錄瀏覽收藏比、距離上次更新等指標。
+   如未安裝 `openpyxl`，則改寫入 `history_table.csv` 與 `worlds.csv`。
+   可使用試算表軟體開啟 `worlds.xlsx`（或 `worlds.csv`）以方便手動編輯。
 3. `python3 scraper/exporter.py`
+
+若要抓取作者世界，需先安裝 `playwright` 套件並執行 `playwright install`。
+若未安裝此套件，圖形介面仍可使用，但無法取得作者創作世界。
 
 完成後，將 `scraper/approved_export.json` 複製到 `docs/` 以更新網站，
 或在 Unity 中使用 `GenerateWorldCards` 編輯器腳本載入。

--- a/world_info/scraper/scraper.py
+++ b/world_info/scraper/scraper.py
@@ -1,45 +1,278 @@
 
 """Retrieve world data from the VRChat API.
 
-This script queries the unofficial VRChat API to fetch world information
-and stores the results as a JSON list.  Authentication headers such as
-cookies should be provided in ``headers.json``.  The file is ignored by
-git so your credentials remain local.
+This script queries the unofficial VRChat API to fetch world information and
+stores the results as a JSON list.  Searching by keyword uses the HTTP API.
+To list a creator's worlds we scrape the website using Playwright because there
+is no stable API endpoint.  Authentication headers can be supplied in
+``headers.json`` or via command line options.  The credentials file is ignored
+by git so your secrets remain local.
 """
 
 from __future__ import annotations
 
+import base64
 import json
+import datetime as dt
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, List, Optional
 import time
 
-import requests
+try:
+    from openpyxl import Workbook, load_workbook  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Workbook = None  # type: ignore
+    load_workbook = None  # type: ignore
+
+import csv
+
+try:
+    from playwright.sync_api import sync_playwright  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    sync_playwright = None  # type: ignore
+
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    requests = None  # type: ignore
 
 BASE = Path(__file__).parent
 HEADERS_FILE = BASE / "headers.json"
+HISTORY_FILE = BASE / "history.json"
+HISTORY_TABLE = BASE / "history_table.xlsx"
+EXCEL_FILE = BASE / "worlds.xlsx"
+HISTORY_TABLE_CSV = HISTORY_TABLE.with_suffix('.csv')
+EXCEL_FILE_CSV = EXCEL_FILE.with_suffix('.csv')
 
 
-def _load_headers() -> Dict[str, str]:
-    """Load HTTP headers from ``headers.json`` if it exists."""
+def _load_headers(cookie: Optional[str] = None,
+                  username: Optional[str] = None,
+                  password: Optional[str] = None) -> Dict[str, str]:
+    """Load HTTP headers from ``headers.json`` and command line options."""
+
+    headers = {"User-Agent": "Mozilla/5.0"}
+
     if HEADERS_FILE.exists():
         with open(HEADERS_FILE, "r", encoding="utf-8") as f:
-            return json.load(f)
-    return {"User-Agent": "Mozilla/5.0"}
+            try:
+                headers.update(json.load(f))
+            except json.JSONDecodeError:
+                pass
+
+    if cookie:
+        headers["Cookie"] = cookie
+
+    if username and password:
+        token = base64.b64encode(f"{username}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {token}"
+
+    return headers
 
 
-HEADERS = _load_headers()
+HEADERS: Dict[str, str] = _load_headers()
 
 
-def _fetch_paginated(base_url: str, limit: int, delay: float) -> List[dict]:
+def record_row(world: dict, now: Optional[int] = None) -> List[object]:
+    """Return a metrics row for history tables and Excel."""
+    ts_now = dt.datetime.fromtimestamp(now, dt.timezone.utc) if isinstance(now, int) else dt.datetime.now(dt.timezone.utc)
+
+    pub = _parse_date(world.get("publicationDate"))
+    updated = _parse_date(world.get("updated_at"))
+    labs = _parse_date(world.get("labsPublicationDate"))
+
+    days_labs_to_pub = (pub - labs).days if pub and labs else ""
+    visits = world.get("visits") or 0
+    favs = world.get("favorites") or 0
+    ratio_vf = round(visits / favs, 2) if favs else ""
+    since_update = (ts_now - updated).days if updated else ""
+    since_pub = (ts_now - pub).days if pub else 0
+    visits_per_day = round(visits / since_pub, 2) if since_pub > 0 else ""
+
+    return [
+        world.get("name"),
+        world.get("id"),
+        world.get("publicationDate"),
+        world.get("updated_at"),
+        visits,
+        world.get("capacity"),
+        favs,
+        world.get("heat"),
+        world.get("popularity"),
+        days_labs_to_pub,
+        ratio_vf,
+        since_update,
+        world.get("releaseStatus"),
+        visits_per_day,
+    ]
+
+
+def _parse_date(value: Optional[str]) -> Optional[dt.datetime]:
+    if not value:
+        return None
+    try:
+        # allow plain dates like "2025/7/12" for manual edits
+        if isinstance(value, (int, float)):
+            return dt.datetime.fromtimestamp(float(value), dt.timezone.utc)
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        if "T" in value:
+            dt_obj = dt.datetime.fromisoformat(value)
+        else:
+            for fmt in ("%Y/%m/%d", "%Y-%m-%d"):
+                try:
+                    dt_obj = dt.datetime.strptime(value, fmt)
+                    break
+                except ValueError:
+                    dt_obj = None
+            if dt_obj is None:
+                return None
+        if dt_obj.tzinfo is None:
+            dt_obj = dt_obj.replace(tzinfo=dt.timezone.utc)
+        return dt_obj
+    except Exception:
+        return None
+
+
+def load_history() -> Dict[str, List[dict]]:
+    """Load the long-term history file if present."""
+    if HISTORY_FILE.exists():
+        with open(HISTORY_FILE, "r", encoding="utf-8") as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+
+def update_history(worlds: List[dict], threshold: int = 3600) -> Dict[str, List[dict]]:
+    """Append new stats to ``history.json`` unless recorded recently."""
+    history = load_history()
+    now = int(time.time())
+    appended = False
+    for w in worlds:
+        wid = w.get("id") or w.get("worldId")
+        if not wid:
+            continue
+        recs = history.setdefault(wid, [])
+        if recs and now - recs[-1].get("timestamp", 0) < threshold:
+            continue
+        rec = {
+            "timestamp": now,
+            "name": w.get("name"),
+            "created_at": w.get("created_at"),
+            "visits": w.get("visits"),
+            "favorites": w.get("favorites"),
+            "heat": w.get("heat"),
+            "popularity": w.get("popularity"),
+            "updated_at": w.get("updated_at"),
+            "publicationDate": w.get("publicationDate"),
+            "labsPublicationDate": w.get("labsPublicationDate"),
+        }
+        recs.append(rec)
+        row = record_row(w, now)
+        _append_history_table(row)
+        _append_excel_row(row)
+        appended = True
+    if appended:
+        with open(HISTORY_FILE, "w", encoding="utf-8") as f:
+            json.dump(history, f, ensure_ascii=False, indent=2)
+    return history
+
+
+def _append_history_table(row: List[object]) -> None:
+    """Append a metrics row to ``history_table.xlsx`` or a CSV fallback."""
+    headers = [
+        "世界名稱",
+        "世界ID",
+        "發布日期",
+        "最後更新",
+        "瀏覽人次",
+        "大小",
+        "收藏次數",
+        "熱度",
+        "人氣",
+        "實驗室到發布",
+        "瀏覽蒐藏比",
+        "距離上次更新",
+        "已發布",
+        "人次發布比",
+    ]
+    if Workbook is not None and load_workbook is not None:
+        if HISTORY_TABLE.exists():
+            wb = load_workbook(HISTORY_TABLE)
+            ws = wb.active
+        else:
+            wb = Workbook()
+            ws = wb.active
+            ws.append(headers)
+        ws.append(row)
+        wb.save(HISTORY_TABLE)
+    else:
+        first = not HISTORY_TABLE_CSV.exists()
+        with open(HISTORY_TABLE_CSV, "a", newline="", encoding="utf-8-sig") as f:
+            w = csv.writer(f)
+            if first:
+                w.writerow(headers)
+            w.writerow(row)
+
+
+def _append_excel_row(row: List[object]) -> None:
+    """Append a metrics row to ``worlds.xlsx`` or CSV if Excel unavailable."""
+    headers = [
+        "世界名稱",
+        "世界ID",
+        "發布日期",
+        "最後更新",
+        "瀏覽人次",
+        "大小",
+        "收藏次數",
+        "熱度",
+        "人氣",
+        "實驗室到發布",
+        "瀏覽蒐藏比",
+        "距離上次更新",
+        "已發布",
+        "人次發布比",
+    ]
+    if Workbook is not None and load_workbook is not None:
+        if EXCEL_FILE.exists():
+            wb = load_workbook(EXCEL_FILE)
+            ws = wb.active
+        else:
+            wb = Workbook()
+            ws = wb.active
+            ws.append(headers)
+        ws.append(row)
+        wb.save(EXCEL_FILE)
+    else:
+        first = not EXCEL_FILE_CSV.exists()
+        with open(EXCEL_FILE_CSV, "a", newline="", encoding="utf-8-sig") as f:
+            w = csv.writer(f)
+            if first:
+                w.writerow(headers)
+            w.writerow(row)
+
+
+def _fetch_paginated(base_url: str, limit: int, delay: float,
+                     headers: Optional[Dict[str, str]] = None) -> List[dict]:
     """Fetch up to ``limit`` worlds from ``base_url`` using pagination."""
+    if requests is None:
+        raise RuntimeError("requests package is required")
     results: List[dict] = []
     offset = 0
     while len(results) < limit:
         remaining = min(60, limit - len(results))
-        url = f"{base_url}&n={remaining}&offset={offset}"
-        r = requests.get(url, headers=HEADERS, timeout=30)
-        r.raise_for_status()
+        sep = '&' if '?' in base_url else '?'  # handle URLs with no query yet
+        url = f"{base_url}{sep}n={remaining}&offset={offset}"
+        try:
+            r = requests.get(url, headers=headers or HEADERS, timeout=30)
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as e:  # pragma: no cover - runtime only
+            if e.response is not None and e.response.status_code == 403:
+                raise RuntimeError(
+                    "403 Forbidden: check your cookie or login credentials"
+                ) from e
+            raise
         chunk = r.json()
         if not isinstance(chunk, list):
             break
@@ -51,14 +284,89 @@ def _fetch_paginated(base_url: str, limit: int, delay: float) -> List[dict]:
     return results[:limit]
 
 
-def search_worlds(keyword: str, limit: int = 20, delay: float = 1.0) -> List[dict]:
+def search_worlds(keyword: str, limit: int = 20, delay: float = 1.0,
+                  headers: Optional[Dict[str, str]] = None) -> List[dict]:
+    if requests is None:
+        raise RuntimeError("requests package is required")
+
     base = f"https://api.vrchat.cloud/api/1/worlds?search={keyword}"
-    return _fetch_paginated(base, limit, delay)
+    return _fetch_paginated(base, limit, delay, headers)
 
 
-def get_user_worlds(user_id: str, limit: int = 20, delay: float = 1.0) -> List[dict]:
-    base = f"https://api.vrchat.cloud/api/1/users/{user_id}/worlds?"
-    return _fetch_paginated(base, limit, delay)
+def _cookie_to_playwright(cookie_str: str) -> List[Dict[str, str]]:
+    """Convert a standard cookie header string into Playwright cookie dicts."""
+    cookies: List[Dict[str, str]] = []
+    for part in cookie_str.split(";"):
+        if "=" in part:
+            name, value = part.strip().split("=", 1)
+            cookies.append({"name": name, "value": value, "url": "https://vrchat.com"})
+    return cookies
+
+
+def get_user_worlds(user_id: str, limit: int = 20, delay: float = 1.0,
+                    headers: Optional[Dict[str, str]] = None) -> List[dict]:
+    """Fetch worlds created by the given user ID.
+
+    VRChat does not expose an official endpoint for this, so we load the
+    user's page using Playwright and parse the world cards from the HTML.
+    """
+
+    if sync_playwright is None:
+        raise RuntimeError("playwright is required for user world scraping")
+    if requests is None:
+        raise RuntimeError("requests package is required")
+
+    headers = headers or HEADERS
+    cookie_str = headers.get("Cookie", "")
+
+    url = f"https://vrchat.com/home/user/{user_id}"
+    results: List[dict] = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context()
+        if cookie_str:
+            context.add_cookies(_cookie_to_playwright(cookie_str))
+        page = context.new_page()
+        page.goto(url)
+        page.wait_for_timeout(int(delay * 1000))
+
+        while len(results) < limit:
+            cards = page.query_selector_all("a[href^='/home/world/wrld_']")
+            for card in cards[len(results):]:
+                name = (card.inner_text() or "").strip()
+                link = card.get_attribute("href") or ""
+                world_id = link.split("/")[-1]
+                results.append({"name": name, "id": world_id})
+                if len(results) >= limit:
+                    break
+
+            if len(results) >= limit:
+                break
+            show_more = page.query_selector("button:has-text('Show More')")
+            if show_more:
+                show_more.click()
+                page.wait_for_timeout(int(delay * 1000))
+            else:
+                break
+
+        browser.close()
+
+    # For each world ID we can fetch detailed info via the official world endpoint
+    details: List[dict] = []
+    for r in results:
+        try:
+            info = requests.get(
+                f"https://api.vrchat.cloud/api/1/worlds/{r['id']}",
+                headers=headers,
+                timeout=30,
+            )
+            info.raise_for_status()
+            details.append(info.json())
+        except requests.HTTPError:
+            continue
+
+    return details[:limit]
 
 
 def extract_info(world: dict) -> Dict[str, object]:
@@ -80,6 +388,20 @@ def extract_info(world: dict) -> Dict[str, object]:
     }
 
 
+def fetch_worlds(*,
+                 keyword: Optional[str] = None,
+                 user_id: Optional[str] = None,
+                 limit: int = 20,
+                 delay: float = 1.0,
+                 headers: Optional[Dict[str, str]] = None) -> List[dict]:
+    """High level helper to fetch worlds by keyword or user ID."""
+    if keyword:
+        return search_worlds(keyword, limit, delay, headers)
+    if user_id:
+        return get_user_worlds(user_id, limit, delay, headers)
+    raise ValueError("keyword or user_id required")
+
+
 def main() -> None:
     import argparse
 
@@ -89,16 +411,23 @@ def main() -> None:
     parser.add_argument("--limit", type=int, default=20, help="maximum worlds")
     parser.add_argument("--delay", type=float, default=1.0, help="seconds between requests")
     parser.add_argument("--out", type=Path, default=BASE / "raw_worlds.json", help="output JSON path")
+    parser.add_argument("--cookie", help="authentication cookie string")
+    parser.add_argument("--username", help="basic auth username")
+    parser.add_argument("--password", help="basic auth password")
     args = parser.parse_args()
 
+    global HEADERS
+    HEADERS = _load_headers(args.cookie, args.username, args.password)
+
     if args.keyword:
-        worlds = search_worlds(args.keyword, args.limit, args.delay)
+        worlds = search_worlds(args.keyword, args.limit, args.delay, HEADERS)
     elif args.user:
-        worlds = get_user_worlds(args.user, args.limit, args.delay)
+        worlds = get_user_worlds(args.user, args.limit, args.delay, HEADERS)
     else:
         parser.error("--keyword or --user is required")
 
     parsed = [extract_info(w) for w in worlds]
+    update_history(worlds)
     with open(args.out, "w", encoding="utf-8") as f:
         json.dump(parsed, f, ensure_ascii=False, indent=2)
     print(f"Saved {len(parsed)} worlds to {args.out}")

--- a/world_info/ui.py
+++ b/world_info/ui.py
@@ -1,99 +1,599 @@
+"""Tkinter GUI for fetching and filtering VRChat world data.
+
+The interface provides several tabs:
+- Entrance: input authentication (cookie or basic auth), a search keyword
+  and creator user ID.
+- Data: fetch worlds by keyword and display the raw JSON.
+- Filter: filter the keyword results by tag and sort order.
+- World List: show the filtered worlds in a simple list.
+- User Worlds: fetch and display worlds created by a specific user.
+
+The tool relies on functions in ``scraper/scraper.py``.  Results are saved
+under that folder for reuse by other scripts.  Fetching a creator's worlds uses
+Playwright to scrape the VRChat website, so the ``playwright`` package must be
+installed and ``playwright install`` executed beforehand.
+"""
+from __future__ import annotations
+
 import json
+import datetime as dt
 from pathlib import Path
 import tkinter as tk
 from tkinter import ttk, messagebox
 
+from scraper.scraper import (
+    fetch_worlds,
+    _load_headers,
+    load_history,
+    update_history,
+    record_row,
+    _parse_date,
+    EXCEL_FILE,
+    HISTORY_TABLE,
+)
+
+try:
+    from openpyxl import load_workbook  # type: ignore
+except Exception:  # pragma: no cover - optional
+    load_workbook = None  # type: ignore
+
 BASE = Path(__file__).resolve().parent
-RAW_FILE = BASE / 'scraper' / 'raw_worlds.json'
-REVIEW_FILE = BASE / 'scraper' / 'reviewed_worlds.json'
+RAW_FILE = BASE / "scraper" / "raw_worlds.json"
+USER_FILE = BASE / "scraper" / "user_worlds.json"
 
 
-class ReviewUI(tk.Tk):
+class WorldInfoUI(tk.Tk):
     def __init__(self) -> None:
         super().__init__()
-        self.title('World Review')
-        self.geometry('600x400')
-        self.worlds = self._load_worlds()
-        self.reviews = self._load_reviews()
-        self.index = 0
-        self._build_widgets()
-        self._show_world()
+        self.title("World Info")
+        self.geometry("800x600")
 
-    def _load_worlds(self):
-        if RAW_FILE.exists():
-            with open(RAW_FILE, 'r', encoding='utf-8') as f:
-                return json.load(f)
-        messagebox.showerror('Error', f'Missing {RAW_FILE}')
-        return []
+        self.headers = {}
+        self.data: list[dict] = []
+        self.user_data: list[dict] = []
+        self.filtered: list[dict] = []
+        self.history: dict[str, list[dict]] = load_history()
 
-    def _load_reviews(self):
-        if REVIEW_FILE.exists():
-            with open(REVIEW_FILE, 'r', encoding='utf-8') as f:
-                return json.load(f)
-        return {}
+        self._build_tabs()
 
-    def _build_widgets(self) -> None:
-        self.label_name = ttk.Label(self, text='', font=('Arial', 14))
-        self.label_name.pack(pady=4)
-        self.text_desc = tk.Text(self, height=10, wrap='word')
-        self.text_desc.pack(fill=tk.BOTH, expand=True, padx=5)
-        frame = ttk.Frame(self)
-        frame.pack(pady=4)
-        ttk.Button(frame, text='Approve', command=self._approve).grid(row=0, column=0, padx=2)
-        ttk.Button(frame, text='Reject', command=self._reject).grid(row=0, column=1, padx=2)
-        ttk.Button(frame, text='Skip', command=self._next).grid(row=0, column=2, padx=2)
-        self.status_label = ttk.Label(frame, text='')
-        self.status_label.grid(row=0, column=3, padx=10)
+    # ------------------------------------------------------------------
+    # UI construction
+    def _build_tabs(self) -> None:
+        self.nb = ttk.Notebook(self)
+        self.nb.pack(fill=tk.BOTH, expand=True)
 
-    def _show_world(self) -> None:
-        if self.index >= len(self.worlds):
-            messagebox.showinfo('Review', 'No more worlds')
-            self.label_name.config(text='')
-            self.text_desc.delete('1.0', tk.END)
-            self.status_label.config(text='')
+        self.tab_entry = ttk.Frame(self.nb)
+        self.tab_data = ttk.Frame(self.nb)
+        self.tab_filter = ttk.Frame(self.nb)
+        self.tab_list = ttk.Frame(self.nb)
+        self.tab_user = ttk.Frame(self.nb)
+        self.tab_history = ttk.Frame(self.nb)
+
+        self.nb.add(self.tab_entry, text="入口")
+        self.nb.add(self.tab_data, text="資料")
+        self.nb.add(self.tab_filter, text="篩選")
+        self.nb.add(self.tab_list, text="世界列表")
+        self.nb.add(self.tab_user, text="個人世界")
+        self.nb.add(self.tab_history, text="歷史記錄")
+
+        self._build_entry_tab()
+        self._build_data_tab()
+        self._build_filter_tab()
+        self._build_list_tab()
+        self._build_user_tab()
+        self._build_history_tab()
+        self._load_local_tables()
+
+    # ------------------------------------------------------------------
+    # Entry tab widgets
+    def _build_entry_tab(self) -> None:
+        f = self.tab_entry
+        row = 0
+        ttk.Label(f, text="Cookie").grid(row=row, column=0, sticky="e")
+        self.var_cookie = tk.StringVar()
+        tk.Entry(f, textvariable=self.var_cookie, width=60).grid(row=row, column=1, padx=4, pady=2)
+        row += 1
+
+        ttk.Label(f, text="Username").grid(row=row, column=0, sticky="e")
+        self.var_user = tk.StringVar()
+        tk.Entry(f, textvariable=self.var_user).grid(row=row, column=1, padx=4, pady=2)
+        row += 1
+
+        ttk.Label(f, text="Password").grid(row=row, column=0, sticky="e")
+        self.var_pass = tk.StringVar()
+        tk.Entry(f, textvariable=self.var_pass, show="*").grid(row=row, column=1, padx=4, pady=2)
+        row += 1
+
+        ttk.Label(f, text="Search Keyword").grid(row=row, column=0, sticky="e")
+        self.var_keyword = tk.StringVar()
+        tk.Entry(f, textvariable=self.var_keyword).grid(row=row, column=1, padx=4, pady=2)
+        row += 1
+
+        ttk.Label(f, text="User ID").grid(row=row, column=0, sticky="e")
+        self.var_userid = tk.StringVar()
+        tk.Entry(f, textvariable=self.var_userid).grid(row=row, column=1, padx=4, pady=2)
+        row += 1
+
+        btn_frame = ttk.Frame(f)
+        btn_frame.grid(row=row, column=0, columnspan=2, pady=4)
+        ttk.Button(btn_frame, text="Search", command=self._on_search).grid(row=0, column=0, padx=2)
+        ttk.Button(btn_frame, text="User Worlds", command=self._on_user).grid(row=0, column=1, padx=2)
+
+    # ------------------------------------------------------------------
+    # Data tab widgets
+    def _build_data_tab(self) -> None:
+        self.text_data = tk.Text(self.tab_data, wrap="word")
+        self.text_data.pack(fill=tk.BOTH, expand=True)
+        ttk.Button(self.tab_data, text="Open Filter", command=lambda: self.nb.select(self.tab_filter)).pack(pady=4)
+
+    # Filter tab widgets
+    def _build_filter_tab(self) -> None:
+        f = self.tab_filter
+        ttk.Label(f, text="Tag").grid(row=0, column=0, sticky="e")
+        self.var_tag = tk.StringVar(value="all")
+        self.box_tag = ttk.Combobox(f, textvariable=self.var_tag, values=["all"])
+        self.box_tag.grid(row=0, column=1, padx=4, pady=2)
+
+        ttk.Label(f, text="Sort").grid(row=1, column=0, sticky="e")
+        self.var_sort = tk.StringVar(value="popular")
+        ttk.Combobox(f, textvariable=self.var_sort, values=["latest", "popular"]).grid(row=1, column=1, padx=4, pady=2)
+
+        ttk.Button(f, text="Apply", command=self._apply_filter).grid(row=2, column=0, columnspan=2, pady=4)
+
+    # World list tab
+    def _build_list_tab(self) -> None:
+        columns = ("name", "visits", "id")
+        self.tree = ttk.Treeview(self.tab_list, columns=columns, show="headings")
+        self.tree.heading("name", text="Name")
+        self.tree.heading("visits", text="Visits")
+        self.tree.heading("id", text="World ID")
+        self.tree.column("name", width=250)
+        self.tree.column("visits", width=80, anchor="e")
+        self.tree.column("id", width=200)
+        vsb = ttk.Scrollbar(self.tab_list, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=vsb.set)
+        self.tree.pack(side="left", fill=tk.BOTH, expand=True)
+        vsb.pack(side="right", fill=tk.Y)
+
+    # User worlds tab
+    def _build_user_tab(self) -> None:
+        f = self.tab_user
+        self.user_nb = ttk.Notebook(f)
+        self.user_nb.pack(fill=tk.BOTH, expand=True)
+
+        self.tab_user_list = ttk.Frame(self.user_nb)
+        self.user_nb.add(self.tab_user_list, text="列表")
+
+        self.user_tree = ttk.Treeview(self.tab_user_list, show="headings")
+        columns = [
+            "世界名稱",
+            "世界ID",
+            "發布日期",
+            "最後更新",
+            "瀏覽人次",
+            "大小",
+            "收藏次數",
+            "熱度",
+            "人氣",
+            "實驗室到發布",
+            "瀏覽蒐藏比",
+            "距離上次更新",
+            "已發布",
+            "人次發布比",
+        ]
+        self.user_tree["columns"] = list(range(len(columns)))
+        for idx, col in enumerate(columns):
+            self.user_tree.heading(str(idx), text=col)
+            self.user_tree.column(str(idx), width=80, anchor="center")
+        vsb = ttk.Scrollbar(self.tab_user_list, orient="vertical", command=self.user_tree.yview)
+        self.user_tree.configure(yscrollcommand=vsb.set)
+        self.user_tree.pack(side="left", fill=tk.BOTH, expand=True)
+        vsb.pack(side="right", fill=tk.Y)
+        self.user_tree.bind("<<TreeviewSelect>>", self._on_select_user_world)
+
+        self.user_canvas = tk.Canvas(self.tab_user_list, bg="white", height=200)
+        self.user_canvas.pack(fill=tk.BOTH, expand=True)
+
+    def _build_history_tab(self) -> None:
+        f = self.tab_history
+        self.var_hist_world = tk.StringVar()
+        self.box_hist_world = ttk.Combobox(f, textvariable=self.var_hist_world, values=list(self.history.keys()))
+        self.box_hist_world.pack(fill=tk.X, pady=2)
+        self.box_hist_world.bind("<<ComboboxSelected>>", self._draw_history)
+        self.canvas = tk.Canvas(f, bg="white")
+        self.canvas.pack(fill=tk.BOTH, expand=True)
+        self._update_history_options()
+
+    def _load_local_tables(self) -> None:
+        """Load existing Excel history and populate the user world list."""
+        if load_workbook is None:
             return
-        w = self.worlds[self.index]
-        self.label_name.config(text=f"{w.get('name')} by {w.get('author')}")
-        desc = (
-            f"ID: {w.get('worldId')}\n"
-            f"Visits: {w.get('visits', 0)}\n"
-            f"Tags: {', '.join(w.get('tags', []))}\n\n"
-            f"{w.get('description', '')}"
-        )
-        self.text_desc.delete('1.0', tk.END)
-        self.text_desc.insert(tk.END, desc)
-        status = self.reviews.get(w['worldId'], 'pending')
-        self.status_label.config(text=status)
+        if EXCEL_FILE.exists():
+            wb = load_workbook(EXCEL_FILE)
+            ws = wb.active
+            for row in ws.iter_rows(min_row=2, values_only=True):
+                self.user_tree.insert("", tk.END, values=row)
+                self.user_data.append({
+                    "世界名稱": row[0],
+                    "世界ID": row[1],
+                    "發布日期": row[2],
+                    "最後更新": row[3],
+                    "瀏覽人次": row[4],
+                    "大小": row[5],
+                    "收藏次數": row[6],
+                    "熱度": row[7],
+                    "人氣": row[8],
+                    "實驗室到發布": row[9],
+                    "瀏覽蒐藏比": row[10],
+                    "距離上次更新": row[11],
+                    "已發布": row[12],
+                    "人次發布比": row[13],
+                })
+            self._create_world_tabs()
+    # ------------------------------------------------------------------
+    # Actions
+    def _load_auth_headers(self) -> None:
+        cookie = self.var_cookie.get() or None
+        user = self.var_user.get() or None
+        pw = self.var_pass.get() or None
+        self.headers = _load_headers(cookie, user, pw)
 
-    def _save(self):
-        with open(REVIEW_FILE, 'w', encoding='utf-8') as f:
-            json.dump(self.reviews, f, ensure_ascii=False, indent=2)
+    def _on_search(self) -> None:
+        self._load_auth_headers()
+        keyword = self.var_keyword.get().strip()
+        if not keyword:
+            messagebox.showerror("Error", "Keyword required")
+            return
+        try:
+            self.data = fetch_worlds(keyword=keyword, limit=50, headers=self.headers)
+            with open(RAW_FILE, "w", encoding="utf-8") as f:
+                json.dump(self.data, f, ensure_ascii=False, indent=2)
+            update_history(self.data)
+            self.history = load_history()
+            self._update_history_options()
+            self.text_data.delete("1.0", tk.END)
+            self.text_data.insert(tk.END, json.dumps(self.data, ensure_ascii=False, indent=2))
+            self._update_tag_options()
+            self.nb.select(self.tab_data)
+        except RuntimeError as e:  # pragma: no cover - runtime only
+            messagebox.showerror("HTTP Error", str(e))
+        except Exception as e:  # pragma: no cover - runtime only
+            messagebox.showerror("Error", str(e))
 
-    def _approve(self):
-        if self.index < len(self.worlds):
-            w = self.worlds[self.index]
-            self.reviews[w['worldId']] = 'approved'
-            self._save()
-            self.index += 1
-            self._show_world()
+    def _on_user(self) -> None:
+        self._load_auth_headers()
+        user_id = self.var_userid.get().strip()
+        if not user_id:
+            messagebox.showerror("Error", "User ID required")
+            return
+        try:
+            self.user_data = fetch_worlds(user_id=user_id, limit=50, headers=self.headers)
+            with open(USER_FILE, "w", encoding="utf-8") as f:
+                json.dump(self.user_data, f, ensure_ascii=False, indent=2)
+            update_history(self.user_data)
+            self.history = load_history()
+            self._update_history_options()
 
-    def _reject(self):
-        if self.index < len(self.worlds):
-            w = self.worlds[self.index]
-            self.reviews[w['worldId']] = 'rejected'
-            self._save()
-            self.index += 1
-            self._show_world()
+            for item in self.user_tree.get_children():
+                self.user_tree.delete(item)
+            for w in self.user_data:
+                row = record_row(w)
+                self.user_tree.insert("", tk.END, values=row)
+            self._create_world_tabs()
+            self.nb.select(self.tab_user)
+        except RuntimeError as e:  # pragma: no cover - runtime only
+            messagebox.showerror("HTTP Error", str(e))
+        except Exception as e:  # pragma: no cover - runtime only
+            messagebox.showerror("Error", str(e))
 
-    def _next(self):
-        self.index += 1
-        self._show_world()
+    def _update_tag_options(self) -> None:
+        tags = set()
+        for w in self.data:
+            for t in w.get("tags", []):
+                tags.add(t)
+        self.box_tag["values"] = ["all"] + sorted(tags)
+        self.var_tag.set("all")
+
+    def _apply_filter(self) -> None:
+        worlds = list(self.data)
+        tag = self.var_tag.get()
+        if tag != "all":
+            worlds = [w for w in worlds if tag in w.get("tags", [])]
+        if self.var_sort.get() == "latest":
+            worlds.sort(key=lambda w: w.get("publicationDate", ""), reverse=True)
+        else:
+            worlds.sort(key=lambda w: w.get("visits", 0), reverse=True)
+        self.filtered = worlds
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        for w in self.filtered:
+            name = w.get("name") or w.get("世界名稱")
+            visits = w.get("visits") or w.get("瀏覽人次")
+            world_id = w.get("id") or w.get("世界ID")
+            self.tree.insert("", tk.END, values=(name, visits, world_id))
+        self.nb.select(self.tab_list)
+
+    def _update_history_options(self) -> None:
+        self.hist_map: dict[str, str] = {}
+        values = []
+        for wid, recs in self.history.items():
+            name = ""
+            if isinstance(recs, list) and recs:
+                name = recs[0].get("name", "")
+            label = f"{name} ({wid})" if name else wid
+            values.append(label)
+            self.hist_map[label] = wid
+        self.box_hist_world["values"] = values
+        if values:
+            self.var_hist_world.set(values[0])
+            self._draw_history()
+
+    def _draw_history(self, event=None) -> None:
+        label = self.var_hist_world.get()
+        world_id = getattr(self, "hist_map", {}).get(label, label)
+        data = self.history.get(world_id, [])
+        self.canvas.delete("all")
+        if not data:
+            return
+        width = int(self.canvas.winfo_width() or 600)
+        height = int(self.canvas.winfo_height() or 300)
+        pad = 40
+        times = [d["timestamp"] for d in data]
+        min_t = min(times)
+        max_t = max(times)
+        if max_t == min_t:
+            max_t += 1
+        scale_x = width - 2 * pad
+        scale_y = height - 2 * pad
+
+        def xy(idx, val, max_val):
+            x = pad + (times[idx] - min_t) / (max_t - min_t) * scale_x
+            y = height - pad - min(val, max_val) / max_val * scale_y
+            return x, y
+
+        colors = {
+            "visits": "blue",
+            "favorites": "green",
+            "heat": "red",
+            "popularity": "purple",
+        }
+        limits = {
+            "visits": 5000,
+            "favorites": 5000,
+            "heat": 10,
+            "popularity": 10,
+        }
+        for key, color in colors.items():
+            points = [xy(i, d.get(key, 0), limits[key]) for i, d in enumerate(data)]
+            for a, b in zip(points, points[1:]):
+                self.canvas.create_line(a[0], a[1], b[0], b[1], fill=color)
+        # axes
+        self.canvas.create_line(pad, height - pad, width - pad, height - pad)
+        self.canvas.create_line(pad, pad, pad, height - pad)
+
+    def _on_select_user_world(self, event=None) -> None:
+        item = self.user_tree.focus()
+        if not item:
+            return
+        values = self.user_tree.item(item, "values")
+        if len(values) < 2:
+            return
+        world_id = values[1]
+        self._draw_user_chart(world_id)
+
+    def _draw_user_chart(self, world_id: str) -> None:
+        data = self.history.get(world_id, [])
+        self.user_canvas.delete("all")
+        if not data:
+            return
+        width = int(self.user_canvas.winfo_width() or 600)
+        height = int(self.user_canvas.winfo_height() or 200)
+        pad = 40
+        times = [d["timestamp"] for d in data]
+        min_t = min(times)
+        max_t = max(times)
+        if max_t == min_t:
+            max_t += 1
+        scale_x = width - 2 * pad
+        scale_y = height - 2 * pad
+
+        def xy(idx, val, max_val):
+            x = pad + (times[idx] - min_t) / (max_t - min_t) * scale_x
+            y = height - pad - min(val, max_val) / max_val * scale_y
+            return x, y
+
+        colors = {"visits": "blue", "favorites": "green", "heat": "red", "popularity": "purple"}
+        limits = {"visits": 5000, "favorites": 5000, "heat": 10, "popularity": 10}
+        for key, color in colors.items():
+            pts = [xy(i, d.get(key, 0), limits[key]) for i, d in enumerate(data)]
+            for a, b in zip(pts, pts[1:]):
+                self.user_canvas.create_line(a[0], a[1], b[0], b[1], fill=color)
+        self.user_canvas.create_line(pad, height - pad, width - pad, height - pad)
+        self.user_canvas.create_line(pad, pad, pad, height - pad)
+
+    def _load_history_rows(self, world_id: str) -> list[dict]:
+        """Return history rows for a world ID."""
+        return list(self.history.get(world_id, []))
+
+    def _draw_world_chart(self, canvas: tk.Canvas, world: dict) -> None:
+        world_id = world.get("id") or world.get("worldId")
+        data = self.history.get(world_id, [])
+        canvas.delete("all")
+        if not data:
+            return
+
+        width = int(canvas.winfo_width() or 600)
+        height = int(canvas.winfo_height() or 200)
+        pad = 40
+
+        times = [d["timestamp"] for d in data]
+        labs = _parse_date(world.get("labsPublicationDate"))
+        pub = _parse_date(world.get("publicationDate"))
+        update_times = []
+        for d in data:
+            u = _parse_date(d.get("updated_at"))
+            if u:
+                update_times.append(int(u.timestamp()))
+
+        extra = [t for t in [labs, pub] if t]
+        t_extra = [int(t.timestamp()) for t in extra] + update_times
+        min_t = min([min(times)] + t_extra) if t_extra else min(times)
+        max_t = max([max(times)] + t_extra) if t_extra else max(times)
+        if max_t == min_t:
+            max_t += 1
+
+        scale_x = width - 2 * pad
+        scale_y = height - 2 * pad
+
+        def x_at(ts: int) -> float:
+            return pad + (ts - min_t) / (max_t - min_t) * scale_x
+
+        def y_val(val: float, limit: float) -> float:
+            return height - pad - min(val, limit) / limit * scale_y
+
+        colors = {
+            "visits": "blue",
+            "favorites": "green",
+            "heat": "red",
+            "popularity": "purple",
+        }
+        limits = {"visits": 10000, "favorites": 10000, "heat": 10, "popularity": 10}
+
+        for key, color in colors.items():
+            pts = []
+            for rec in data:
+                ts = rec["timestamp"]
+                val = rec.get(key, 0) or 0
+                pts.append((x_at(ts), y_val(val, limits[key])))
+            for a, b in zip(pts, pts[1:]):
+                canvas.create_line(a[0], a[1], b[0], b[1], fill=color)
+
+        # event lines
+        if labs:
+            x = x_at(int(labs.timestamp()))
+            canvas.create_line(x, pad, x, height - pad, fill="orange", dash=(4, 2))
+        if pub:
+            x = x_at(int(pub.timestamp()))
+            canvas.create_line(x, pad, x, height - pad, fill="black", dash=(4, 2))
+        for t in update_times:
+            x = x_at(t)
+            canvas.create_line(x, pad, x, height - pad, fill="gray", dash=(2, 2))
+
+        canvas.create_line(pad, height - pad, width - pad, height - pad)
+        canvas.create_line(pad, pad, pad, height - pad)
+        canvas.create_line(width - pad, pad, width - pad, height - pad)
+
+    def _create_world_tabs(self) -> None:
+        """Create sub-tabs for each fetched user world with history."""
+        if not hasattr(self, "user_nb"):
+            return
+        # remove old tabs except the first (list tab)
+        for tab_id in self.user_nb.tabs()[1:]:
+            self.user_nb.forget(tab_id)
+        for w in self.user_data:
+            frame = ttk.Frame(self.user_nb)
+
+            # section 1: latest fetched info
+            sec1 = ttk.LabelFrame(frame, text="本次資料")
+            sec1.pack(fill=tk.X, padx=4, pady=2)
+            info_tree = ttk.Treeview(sec1, columns=("k", "v"), show="headings", height=8)
+            info_tree.heading("k", text="欄位")
+            info_tree.heading("v", text="值")
+            for key, val in w.items():
+                info_tree.insert("", tk.END, values=(key, val))
+            info_tree.pack(fill=tk.BOTH, expand=True)
+
+            # section 2: history table from CSV
+            sec2 = ttk.LabelFrame(frame, text="歷史紀錄")
+            sec2.pack(fill=tk.BOTH, expand=True, padx=4, pady=2)
+            hist_tree = ttk.Treeview(sec2, show="headings")
+            cols = [
+                "timestamp",
+                "visits",
+                "favorites",
+                "heat",
+                "popularity",
+                "updated_at",
+                "created_at",
+                "labs",
+                "pub",
+                "days_to_pub",
+                "days_since_upd",
+                "visits_per_day",
+                "fav_per_day",
+            ]
+            hist_tree["columns"] = cols
+            headers = [
+                "時間",
+                "人次",
+                "收藏",
+                "熱度",
+                "熱門度",
+                "更新",
+                "上傳",
+                "實驗室",
+                "公開",
+                "上傳到公開",
+                "距離更新",
+                "人次/天",
+                "收藏/天",
+            ]
+            for c, h in zip(cols, headers):
+                hist_tree.heading(c, text=h)
+                hist_tree.column(c, width=80, anchor="center")
+            rows = self._load_history_rows(w.get("id") or w.get("worldId"))
+            for r in rows:
+                ts = r["timestamp"]
+                ts_dt = dt.datetime.fromtimestamp(ts, dt.timezone.utc)
+                upd = _parse_date(r.get("updated_at"))
+                created = _parse_date(r.get("created_at"))
+                labs = _parse_date(r.get("labsPublicationDate"))
+                pub = _parse_date(r.get("publicationDate"))
+                days_to_pub = ""
+                if pub and created:
+                    days_to_pub = (pub - created).days
+                elif pub and labs:
+                    days_to_pub = (pub - labs).days
+                days_since = (ts_dt - upd).days if upd else ""
+                since_pub = (ts_dt - pub).days if pub else 0
+                vpd = round((r.get("visits", 0) or 0) / since_pub, 2) if since_pub > 0 else ""
+                fpd = round((r.get("favorites", 0) or 0) / since_pub, 2) if since_pub > 0 else ""
+                hist_tree.insert(
+                    "",
+                    tk.END,
+                    values=(
+                        ts,
+                        r.get("visits"),
+                        r.get("favorites"),
+                        r.get("heat"),
+                        r.get("popularity"),
+                        r.get("updated_at"),
+                        r.get("created_at"),
+                        r.get("labsPublicationDate"),
+                        r.get("publicationDate"),
+                        days_to_pub,
+                        days_since,
+                        vpd,
+                        fpd,
+                    ),
+                )
+            hist_tree.pack(fill=tk.BOTH, expand=True)
+
+            # section 3: chart
+            sec3 = ttk.LabelFrame(frame, text="折線圖")
+            sec3.pack(fill=tk.BOTH, expand=True, padx=4, pady=2)
+            canvas = tk.Canvas(sec3, bg="white", height=200)
+            canvas.pack(fill=tk.BOTH, expand=True)
+            self.after(100, lambda c=canvas, ww=w: self._draw_world_chart(c, ww))
+
+            name = w.get("name") or w.get("世界名稱") or w.get("id")
+            self.user_nb.add(frame, text=str(name)[:15])
 
 
-def main() -> None:
-    app = ReviewUI()
+def main() -> None:  # pragma: no cover - simple runtime entry
+    app = WorldInfoUI()
     app.mainloop()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- make `openpyxl` and `requests` optional in the scraper
- skip Excel logging if `openpyxl` isn't installed
- ensure functions that use `requests` fail with a helpful error
- add a sub-notebook with one tab per fetched world
- write `history_table.xlsx` with a UTF‑8 BOM when first created
- show latest data, history table and chart on each world tab
- record world update timestamps in the history JSON
- parse simple date formats and record world names in history
- show world names in the history tab and expand the per-world tables
- load previous Excel log on UI startup
- **Provide CSV fallback for history logs**

## Testing
- `python -m py_compile world_info/scraper/scraper.py world_info/ui.py track_results/fetch_sheet.py track_results/build_leaderboards.py track_results/ui.py`
- `pip install -r requirements.txt` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6886da21df6c832da5455e0368c9dcb0