### PR TITLE
Handle empty world data and extra table columns

### DIFF
--- a/track_results/ui.py
+++ b/track_results/ui.py
@@ -22,8 +22,8 @@ class WorldReviewTab(ttk.Frame):
     def __init__(self, master: ttk.Frame) -> None:
         super().__init__(master)
         self.pack(fill=tk.BOTH, expand=True)
-        self.worlds = self._load_json(RAW_FILE)
-        self.reviews = self._load_json(REVIEW_FILE, default={})
+        self.worlds = self._load_json(RAW_FILE, [])
+        self.reviews = self._load_json(REVIEW_FILE, {})
         self.index = 0
         self._build_widgets()
         self._show_world()
@@ -52,6 +52,11 @@ class WorldReviewTab(ttk.Frame):
             json.dump(self.reviews, f, ensure_ascii=False, indent=2)
 
     def _show_world(self):
+        if not self.worlds:
+            self.label_name.config(text="無資料")
+            self.text_desc.delete("1.0", tk.END)
+            self.status_label.config(text="")
+            return
         if self.index >= len(self.worlds):
             self.label_name.config(text="")
             self.text_desc.delete("1.0", tk.END)

--- a/world_info/ui.py
+++ b/world_info/ui.py
@@ -322,7 +322,8 @@ class WorldInfoUI(tk.Tk):
             ws = wb.active
             for row in ws.iter_rows(min_row=2, values_only=True):
                 self.user_tree.insert("", tk.END, values=row)
-                if len(row) == 15:
+                if len(row) >= 15:
+                    row = row[:15]
                     (
                         fetched,
                         name,
@@ -340,8 +341,9 @@ class WorldInfoUI(tk.Tk):
                         released,
                         vpp,
                     ) = row
-                else:
+                elif len(row) >= 14:
                     # backward compatibility with old files without fetch date
+                    row = row[:14]
                     fetched = ""
                     (
                         name,
@@ -359,6 +361,9 @@ class WorldInfoUI(tk.Tk):
                         released,
                         vpp,
                     ) = row
+                else:
+                    # skip rows that don't have enough columns
+                    continue
                 self.user_data.append(
                     {
                         "爬取日期": fetched,


### PR DESCRIPTION
## Summary
- Default world and review data to empty collections when JSON files are absent
- Trim extra columns and skip short rows when loading personal world tables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890631359f8832d8c677becca69bfca