### PR TITLE
Fix duplicate rows when refreshing user worlds

### DIFF
--- a/tests/test_search_personal_no_duplicates.py
+++ b/tests/test_search_personal_no_duplicates.py
@@ -1,0 +1,71 @@
+import types
+import sys
+from pathlib import Path
+
+
+def test_search_personal_no_duplicates(monkeypatch):
+    base = Path(__file__).resolve().parent.parent
+    sys.path.append(str(base))
+    sys.path.append(str(base / "world_info"))
+    from world_info import ui as ui_module
+
+    saved_worlds: list[dict] = []
+
+    def fake_search_user(user_id, headers):
+        return [{"id": "w1", "name": "World"}]
+
+    def fake_save_worlds(worlds, file):
+        saved_worlds.extend(worlds)
+
+    def fake_update_history(worlds):
+        pass
+
+    def fake_load_history():
+        return {}
+
+    def fake_update_daily_stats(source, worlds):
+        pass
+
+    def fake_load_local_tables(self):
+        # intentionally do not clear tree here to ensure _search_personal does
+        self.user_data = [{"世界ID": w["id"]} for w in saved_worlds]
+        for w in saved_worlds:
+            self.user_tree.insert("", None, values=(w["id"],))
+
+    monkeypatch.setattr(ui_module, "search_user", fake_search_user)
+    monkeypatch.setattr(ui_module, "save_worlds", fake_save_worlds)
+    monkeypatch.setattr(ui_module, "update_history", fake_update_history)
+    monkeypatch.setattr(ui_module, "load_history", fake_load_history)
+    monkeypatch.setattr(ui_module, "update_daily_stats", fake_update_daily_stats)
+
+    class MockTree:
+        def __init__(self):
+            self.items = []
+
+        def get_children(self):
+            return list(self.items)
+
+        def delete(self, item):
+            self.items.remove(item)
+
+        def insert(self, parent, index, values):
+            self.items.append(values)
+
+    ui = types.SimpleNamespace()
+    ui._load_auth_headers = lambda: None
+    ui.settings = {"player_id": "user123"}
+    ui.headers = {}
+    ui.user_tree = MockTree()
+    ui.user_data = []
+    ui.history = {}
+    ui._update_history_options = lambda: None
+    ui.nb = types.SimpleNamespace(select=lambda frame: None)
+    ui.tab_user = types.SimpleNamespace(frame=object())
+    ui._load_local_tables = lambda: fake_load_local_tables(ui)
+
+    ui_module.WorldInfoUI._search_personal(ui)
+    assert len(ui.user_tree.get_children()) == 1
+
+    ui_module.WorldInfoUI._search_personal(ui)
+    assert len(ui.user_tree.get_children()) == 1
+

--- a/world_info/ui.py
+++ b/world_info/ui.py
@@ -290,12 +290,20 @@ class WorldInfoUI(tk.Tk):
         fetch_date = dt.datetime.now(dt.timezone.utc).strftime("%Y/%m/%d")
         for w in worlds:
             w["爬取日期"] = fetch_date
+        # remove already recorded worlds so repeated searches don't duplicate rows
+        existing_ids = {w.get("世界ID") for w in self.user_data if w.get("世界ID")}
+        worlds = [w for w in worlds if w.get("id") not in existing_ids]
 
-        save_worlds(worlds, PERSONAL_FILE)
-        update_history(worlds)
-        self.history = load_history()
-        self._update_history_options()
-        update_daily_stats("starriver", worlds)
+        # clear current rows before inserting the refreshed data
+        for item in self.user_tree.get_children():
+            self.user_tree.delete(item)
+
+        if worlds:
+            save_worlds(worlds, PERSONAL_FILE)
+            update_history(worlds)
+            self.history = load_history()
+            self._update_history_options()
+            update_daily_stats("starriver", worlds)
 
         # reload the table so manual edits remain and new data is visible
         self._load_local_tables()


### PR DESCRIPTION
## Summary
- clear existing user world rows and skip already-recorded world IDs in `_search_personal`
- add regression test ensuring `_search_personal` doesn't duplicate worlds on repeated runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68993fc9da6c832db9de509c883c5fbd