### PR TITLE
docs: update world info prefab and upload guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ VRChat 工具集是一個互動式工具組，包含賽道成績 (Track Results)
 
 ## 功能簡介
 - **Track Results**：下載賽車紀錄並建立文字或 HTML 排行榜，並可產生包含總筆數、各賽道最快與車手最佳時間的統計摘要。詳見 [`track_results/README.md`](track_results/README.md)。
-- **World Info**：收集世界資訊、維護歷史資料並提供圖形審核介面；執行爬蟲時會顯示各模式進度並於結束後輸出抓取的世界總數。詳見 [`world_info/README.md`](world_info/README.md)。
+- **World Info**：收集世界資訊、維護歷史資料並提供圖形審核介面；可定期上傳個人世界統計到雲端，並透過 Unity 產生可在 VRChat 中使用的 UI Prefab。詳見 [`world_info/README.md`](world_info/README.md)。
 
 ## 資料來源
 - Google 試算表

--- a/README.zh_TW.md
+++ b/README.zh_TW.md
@@ -6,7 +6,7 @@
 用於從 Google 試算表下載賽車紀錄並產生文字或 HTML 形式的排行榜，也可輸出包含總筆數、各賽道最快與車手最佳時間的統計摘要。詳盡使用方式請參考 [`track_results/README.zh_TW.md`](track_results/README.zh_TW.md)。
 
 ## 世界資料（World Info）
-用於收集 VRChat 世界資訊、人工審核並匯出可在網站或 Unity 中使用的 JSON 檔案，並附帶簡易的 Tkinter 圖形審核介面。詳細流程請參考 [`world_info/README.zh_TW.md`](world_info/README.zh_TW.md)。更完整的架構與流程說明請見 [`world_info/complete_guide.zh_TW.md`](world_info/complete_guide.zh_TW.md)。
+用於收集 VRChat 世界資訊、人工審核並匯出可在網站或 Unity 中使用的 JSON 檔案，附帶簡易的 Tkinter 圖形審核介面。支援定期上傳個人世界統計到雲端，並能利用 Unity 產生可在 VRChat 內顯示的 UI Prefab。詳細流程請參考 [`world_info/README.zh_TW.md`](world_info/README.zh_TW.md)，更完整的架構與流程說明請見 [`world_info/complete_guide.zh_TW.md`](world_info/complete_guide.zh_TW.md)。
 
 ## CREDIT
 星河 StarRiver、Codex AI

--- a/world_info/README.md
+++ b/world_info/README.md
@@ -16,7 +16,8 @@ world_info/
 │  ├─ index.html          # page listing approved worlds with filters
 │  └─ approved_export.json
 └─ unity_prefab_generator/
-   └─ GenerateWorldCards.cs
+   ├─ GenerateWorldCards.cs       # editor script that builds a VRChat-ready prefab
+   └─ WorldCardTemplate.prefab    # template card referenced by the generator
 ```
 
 Install the required Python packages with::
@@ -67,7 +68,10 @@ is missing, the UI will still run but the creator-world feature will be
 disabled.
 
 Copy `scraper/approved_export.json` into `docs/` to update the website or load
-it inside Unity using the `GenerateWorldCards` editor script.
+it inside Unity.  The `unity_prefab_generator/GenerateWorldCards.cs` script
+instantiates `WorldCardTemplate.prefab` for each world and saves the result as
+`GeneratedWorldCards.prefab`, which can be dropped into a VRChat scene as a
+scrollable screen.
 
 For a Traditional Chinese version of these instructions, see
 [`README.zh_TW.md`](README.zh_TW.md).

--- a/world_info/README.zh_TW.md
+++ b/world_info/README.zh_TW.md
@@ -9,13 +9,15 @@ world_info/
 │  ├─ scraper.py          # 從 VRChat API 取得世界資料
 │  ├─ review_tool.py      # 標記世界是否核可
 │  ├─ exporter.py         # 產生 approved_export.json
+│  ├─ personal_upload.py  # 上傳個人世界統計到雲端
 │  └─ raw_worlds.json     # 產生的範例資料
 ├─ ui.py                  # Tkinter 介面，可登入並搜尋世界
 ├─ docs/
 │  ├─ index.html          # 提供篩選功能的世界清單頁面
 │  └─ approved_export.json
 └─ unity_prefab_generator/
-   └─ GenerateWorldCards.cs
+   ├─ GenerateWorldCards.cs    # 依模板生成可在 VRChat 使用的 Prefab
+   └─ WorldCardTemplate.prefab # 世界卡片範本
 ```
 
 執行前請先安裝 Python 套件：
@@ -51,12 +53,15 @@ playwright install
    追加一行，記錄瀏覽收藏比、距離上次更新，以及資料爬取日期（`YYYY/MM/DD`）。
    這些 Excel 檔需安裝 `openpyxl` 套件後才能正確寫入，可直接以試算表軟體開啟編輯。
 3. `python3 scraper/exporter.py`
+4. 若要上傳個人世界統計，執行 `python3 scraper/personal_upload.py`
 
 若要抓取作者世界，需先安裝 `playwright` 套件並執行 `playwright install`。
 若未安裝此套件，圖形介面仍可使用，但無法取得作者創作世界。
 
 完成後，將 `scraper/approved_export.json` 複製到 `docs/` 以更新網站，
-或在 Unity 中使用 `GenerateWorldCards` 編輯器腳本載入。
+或在 Unity 中使用 `GenerateWorldCards` 編輯器腳本載入。該腳本會
+根據 `WorldCardTemplate.prefab` 為每個世界建立卡片，並輸出可直接
+放入 VRChat 場景的 `GeneratedWorldCards.prefab`。
 
 更多背景與架構說明請參考
 [`complete_guide.zh_TW.md`](complete_guide.zh_TW.md)。

--- a/world_info/complete_guide.zh_TW.md
+++ b/world_info/complete_guide.zh_TW.md
@@ -26,6 +26,7 @@
 │  ├─ scraper.py
 │  ├─ review_tool.py
 │  ├─ exporter.py
+│  ├─ personal_upload.py
 │  ├─ raw_worlds.json
 │  ├─ reviewed_worlds.json
 │  └─ approved_export.json
@@ -44,8 +45,9 @@
 1. `scraper.py`：登入 VRChat、搜尋關鍵字取得世界資料並輸出 `raw_worlds.json`。
 2. `review_tool.py`：讀取 raw 資料，人工標記為 approved 或 rejected，結果存入 `reviewed_worlds.json`。
 3. `exporter.py`：濾除未核可的世界，產生 `approved_export.json`。
-4. `docs/index.html`：於 GitHub Pages 顯示世界清單。
-5. `GenerateWorldCards.cs`：在 Unity 中讀取 JSON，產生推薦圖卡 Prefab。
+4. `personal_upload.py`：把特定玩家的世界統計上傳到雲端。
+5. `docs/index.html`：於 GitHub Pages 顯示世界清單。
+6. `GenerateWorldCards.cs`：在 Unity 中依 `WorldCardTemplate.prefab` 建立卡片，輸出可在 VRChat 內作為螢幕的 Prefab。
 
 ## JSON 範例
 


### PR DESCRIPTION
## Summary
- Document personal world stat uploads and VRChat prefab generation in the root and world_info READMEs
- Expand the complete guide with personal_upload and GenerateWorldCards steps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a529c9eda4832daa64a30e15850342